### PR TITLE
Created at vs last updated at bug

### DIFF
--- a/functions_helper.py
+++ b/functions_helper.py
@@ -56,8 +56,8 @@ def create_initial_habits():
         predefined_habits = json.load(f)
 
     for habit_data in predefined_habits:
-        created_at = datetime.now() - timedelta(days=random.randint(1, 365))
         last_updated_at = datetime.now() - timedelta(days=random.randint(1, 10))
+        created_at = last_updated_at - timedelta(days=random.randint(1, 365))
         max_streak = check_max_streak(habit_data["periodicity"], created_at, last_updated_at)
         if date_check_with_periodicity(habit_data["periodicity"], last_updated_at) != "Streak Expired":
             # TODO: max_streak is sometimes -1, when periodicity is weekly


### PR DESCRIPTION
There was a misunderstanding from my side, I didn't think of the chance that the created_at date could be more recent than last_updated at. Now this can't happen anymore

Logic before:
```
created_at = random day between today and 1 year ago
last_updated_at = random day between today and 10 days ago
```

Logic now:
```
last_updated_at = random day between today and 10 days ago
created_at = random day between last_updated_at and 365 days before that date
```