### PR TITLE
Handling missing habit name

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,6 +38,8 @@ def get_habit(name):
 def create_habit():
     data = request.json
     name = data['name'].title()
+    if name == '':
+        return jsonify({'message': 'Habit name cannot be empty'}), 400
     periodicity = data['periodicity']
     habit = Habit(name=name, periodicity=periodicity, created_at=datetime.now(), streak=0, last_updated_at=datetime.now())
     habit.create_habit()

--- a/templates/index.html
+++ b/templates/index.html
@@ -80,6 +80,10 @@
         async function createHabit() {
             const name = document.getElementById('habit-name').value;
             const periodicity = document.getElementById('habit-periodicity').value;
+            if (!name.trim()) {
+                alert('Habit name is required');
+                return;
+            }
             const response = await fetch('/habits', {
                 method: 'POST',
                 headers: {
@@ -196,7 +200,7 @@
     </div>
     <div>
         <h2>Create Habit</h2>
-        <input type="text" id="habit-name" placeholder="Habit name">
+        <input type="text" id="habit-name" placeholder="Habit name" required>
         <select id="habit-periodicity">
             <option value="D">Daily</option>
             <option value="W">Weekly</option>


### PR DESCRIPTION
Now the user can't create a habit with an empty name (`""`), this was secured both on the side of the `app.py` (if name is empty, stop creating the habit) and on the side of `index.html`, not even letting the user do this action in the first place