### PR TITLE
feat: longest-overall-streak

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,3 +171,15 @@ def get_longest_monthly_streak():
     habit = Habit()
     streak = habit.longest_monthly_streak()
     return jsonify(streak)
+
+@app.route('/streaks/longest', methods=['GET'])
+def get_longest_streak():
+    """
+    Get the longest streak.
+
+    Returns:
+    JSON: The longest streak.
+    """
+    database = Database()
+    name, date, streak = database.get_longest_active_streak()
+    return jsonify({'habit': name, 'date': date, 'streak': streak})

--- a/habit.py
+++ b/habit.py
@@ -166,6 +166,17 @@ class Habit:
         longest_streak = cur.fetchall()
         cur.close()
         return longest_streak
+    
+    def get_longest_overall_streak(self):
+        """
+        Get the longest overall streak. This needs to take into account the periodicity of the habit.
+        Each habit can have a different periodicity ('D', 'W', 'M'). 
+        And each streak just represents one completed period of that periodicity for that habit
+
+        Returns:
+        list: The longest overall streak.
+        """
+        pass
 
     def get_tracking_data(self):
         """

--- a/templates/index.html
+++ b/templates/index.html
@@ -226,14 +226,17 @@
             const dailyResponse = await fetch('/streaks/daily');
             const weeklyResponse = await fetch('/streaks/weekly');
             const monthlyResponse = await fetch('/streaks/monthly');
+            const overallResponse = await fetch('/streaks/longest');
 
             const dailyStreak = await dailyResponse.json();
             const weeklyStreak = await weeklyResponse.json();
             const monthlyStreak = await monthlyResponse.json();
+            const overallStreak = await overallResponse.json();
 
             document.getElementById('daily-streak').textContent = dailyStreak.length > 0 ? `Longest daily streak: ${dailyStreak[0][0]} with ${dailyStreak[0][1]} days` : 'No daily streaks found';
             document.getElementById('weekly-streak').textContent = weeklyStreak.length > 0 ? `Longest weekly streak: ${weeklyStreak[0][0]} with ${weeklyStreak[0][1]} weeks` : 'No weekly streaks found';
             document.getElementById('monthly-streak').textContent = monthlyStreak.length > 0 ? `Longest monthly streak: ${monthlyStreak[0][0]} with ${monthlyStreak[0][1]} months` : 'No monthly streaks found';
+            document.getElementById('longest-overall-streak').textContent = Object.keys(overallStreak).length > 0 ? `Longest streak overall: ${overallStreak.habit}, since ${overallStreak.date}, with a streak of ${overallStreak.streak}` : 'No overall streaks found';
         }
 
         async function searchLongestStreak() {
@@ -345,6 +348,7 @@
         <p id="daily-streak"></p>
         <p id="weekly-streak"></p>
         <p id="monthly-streak"></p>
+        <p id="longest-overall-streak"></p>
     </div>
     <div>
         <h2>Search Longest Streak</h2>


### PR DESCRIPTION
Returning the overall oldest active streak, by looking at the oldest date of the current active streaks, to compare directly between monthly, weekly and daily